### PR TITLE
feat: Implement i18n for POS and Super Admin, and show table number

### DIFF
--- a/src/components/pos/TableManagementTab.tsx
+++ b/src/components/pos/TableManagementTab.tsx
@@ -129,7 +129,7 @@ export const TableManagementTab: React.FC = () => {
     e.preventDefault();
     
     if (!user) {
-      toast.error("يجب تسجيل الدخول أولاً");
+      toast.error(t('pos.tables.loginRequired'));
       return;
     }
 
@@ -299,7 +299,7 @@ export const TableManagementTab: React.FC = () => {
                   id="table_number"
                   value={formData.table_number}
                   onChange={(e) => setFormData({ ...formData, table_number: e.target.value })}
-                  placeholder={isRTL ? "مثال: 1" : "e.g. 1"}
+                  placeholder={t('pos.tables.tableNumberPlaceholder')}
                   required
                 />
               </div>
@@ -315,7 +315,7 @@ export const TableManagementTab: React.FC = () => {
                   <SelectContent>
                     {[1, 2, 3, 4, 5, 6, 8, 10].map((num) => (
                       <SelectItem key={num} value={num.toString()}>
-                        {num} {num === 1 ? (isRTL ? 'شخص' : 'person') : (isRTL ? 'أشخاص' : 'people')}
+                        {num} {t(num === 1 ? 'pos.tables.person' : 'pos.tables.people')}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -327,7 +327,7 @@ export const TableManagementTab: React.FC = () => {
                   id="location_area"
                   value={formData.location_area}
                   onChange={(e) => setFormData({ ...formData, location_area: e.target.value })}
-                  placeholder={isRTL ? "مثال: الدور الأول، النافذة، الشرفة" : "e.g. First floor, Window, Terrace"}
+                  placeholder={t('pos.tables.locationPlaceholder')}
                 />
               </div>
               <div className="flex justify-end gap-2">
@@ -419,7 +419,7 @@ export const TableManagementTab: React.FC = () => {
               <CardHeader className="pb-2">
                 <div className="flex items-center justify-between">
                   <CardTitle className="text-lg">
-                    {isRTL ? `طاولة #${table.table_number}` : `Table #${table.table_number}`}
+                    {t('pos.tables.tableTitle', { number: table.table_number })}
                   </CardTitle>
                   <Badge className={getStatusColor(status)}>
                     {getStatusIcon(status)}
@@ -434,7 +434,7 @@ export const TableManagementTab: React.FC = () => {
                 <div className="space-y-3">
                   <div className="flex items-center gap-2 text-sm">
                     <Users className="w-4 h-4 text-muted-foreground" />
-                    <span>{table.capacity} {table.capacity === 1 ? (isRTL ? 'شخص' : 'person') : (isRTL ? 'أشخاص' : 'people')}</span>
+                    <span>{table.capacity} {t(table.capacity === 1 ? 'pos.tables.person' : 'pos.tables.people')}</span>
                   </div>
                   
                   {table.location_area && (
@@ -478,7 +478,7 @@ export const TableManagementTab: React.FC = () => {
                           const qrImageUrl = `https://api.qrserver.com/v1/create-qr-code/?size=300x300&format=png&data=${encodeURIComponent(dataUrl)}`;
                           window.open(qrImageUrl, '_blank');
                         } else {
-                          toast.error(isRTL ? "لا يوجد رمز QR لهذه الطاولة" : "No QR code for this table");
+                          toast.error(t('pos.tables.noQrCode'));
                         }
                       }}
                       className="flex-1"

--- a/src/i18n/ar.json
+++ b/src/i18n/ar.json
@@ -52,12 +52,14 @@
       "pendingApproval": "في انتظار الموافقة",
       "newOrder": "طلب جديد!",
       "orderNumber": "رقم الطلب",
+      "newOrderNotification": "طلب جديد #{{orderNumber}} - {{totalAmount}} {{currency}}",
       "orderUpdated": "تم تحديث الطلب",
       "statusChanged": "تم تغيير الحالة إلى",
       "loadError": "خطأ في تحميل طلبات نقاط البيع",
       "updateError": "خطأ في تحديث حالة الطلب",
       "online": "متصل",
-      "offline": "غير متصل"
+      "offline": "غير متصل",
+      "tableBadge": "طاولة #{{tableNumber}}"
     },
     "status": {
       "new": "جديد",
@@ -112,7 +114,14 @@
       "totalCapacity": "إجمالي السعة",
       "edit": "تعديل",
       "noTables": "لا توجد طاولات مضافة بعد",
-      "addFirstTable": "إضافة أول طاولة"
+      "addFirstTable": "إضافة أول طاولة",
+      "loginRequired": "يجب تسجيل الدخول أولاً",
+      "tableNumberPlaceholder": "مثال: 1",
+      "person": "شخص",
+      "people": "أشخاص",
+      "locationPlaceholder": "مثال: الدور الأول، النافذة، الشرفة",
+      "tableTitle": "طاولة #{{number}}",
+      "noQrCode": "لا يوجد رمز QR لهذه الطاولة"
     },
     "notifications": {
       "title": "إعدادات الإشعارات",
@@ -127,7 +136,9 @@
       "description": "أنت غير متصل بالإنترنت، سيتم مزامنة التغييرات عند عودة الاتصال",
       "queuedOrders": "طلبات في قائمة الانتظار",
       "syncPending": "في انتظار المزامنة",
-      "syncComplete": "تم التزامن"
+      "syncComplete": "تم التزامن",
+      "syncSuccessMessage": "تم تزامن {{count}} طلب",
+      "syncSuccessMessage_plural": "تم تزامن {{count}} طلبات"
     }
   },
   "auth": {
@@ -426,12 +437,12 @@
     "welcome": "مرحباً بك {{name}}",
     "stats": {
       "totalRestaurants": "إجمالي المطاعم",
-      "paidPlans": "الخطط المدفوعة",
-      "activeAccounts": "الحسابات النشطة",
-      "analytics": "التحليلات",
       "activeCount": "{{count}} نشط",
+      "paidPlans": "الخطط المدفوعة",
       "outOfTotal": "من أصل {{total}}",
+      "activeAccounts": "الحسابات النشطة",
       "activityPercentage": "{{percentage}}% نشط",
+      "analytics": "التحليلات",
       "analyticsDescription": "عرض تحليلات مفصلة"
     },
     "tenantsManagement": {
@@ -474,7 +485,7 @@
   },
   "plans": {
     "basic": "أساسي",
-    "premium": "متقدم",
+    "premium": "مميز",
     "enterprise": "مؤسسي"
   },
   "features": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -52,12 +52,14 @@
       "pendingApproval": "Pending Approval",
       "newOrder": "New Order!",
       "orderNumber": "Order Number",
+      "newOrderNotification": "New Order #{{orderNumber}} - {{totalAmount}} {{currency}}",
       "orderUpdated": "Order Updated",
       "statusChanged": "Status changed to",
       "loadError": "Error loading POS orders",
       "updateError": "Error updating order status",
       "online": "Online",
-      "offline": "Offline"
+      "offline": "Offline",
+      "tableBadge": "Table #{{tableNumber}}"
     },
     "status": {
       "new": "New",
@@ -112,7 +114,14 @@
       "totalCapacity": "Total Capacity",
       "edit": "Edit",
       "noTables": "No tables added yet",
-      "addFirstTable": "Add your first table"
+      "addFirstTable": "Add your first table",
+      "loginRequired": "You must be logged in to do that",
+      "tableNumberPlaceholder": "e.g. 1",
+      "person": "person",
+      "people": "people",
+      "locationPlaceholder": "e.g. First floor, Window, Terrace",
+      "tableTitle": "Table #{{number}}",
+      "noQrCode": "No QR code for this table"
     },
     "notifications": {
       "title": "Notification Settings",
@@ -127,7 +136,9 @@
       "description": "You're offline, changes will sync when connection is restored",
       "queuedOrders": "Queued Orders",
       "syncPending": "Sync Pending",
-      "syncComplete": "Sync Complete"
+      "syncComplete": "Sync Complete",
+      "syncSuccessMessage": "Synced {{count}} order",
+      "syncSuccessMessage_plural": "Synced {{count}} orders"
     }
   },
   "auth": {
@@ -420,12 +431,12 @@
     "welcome": "Welcome {{name}}",
     "stats": {
       "totalRestaurants": "Total Restaurants",
-      "paidPlans": "Paid Plans",
-      "activeAccounts": "Active Accounts",
-      "analytics": "Analytics",
       "activeCount": "{{count}} active",
+      "paidPlans": "Paid Plans",
       "outOfTotal": "out of {{total}}",
+      "activeAccounts": "Active Accounts",
       "activityPercentage": "{{percentage}}% active",
+      "analytics": "Analytics",
       "analyticsDescription": "View detailed analytics"
     },
     "tenantsManagement": {


### PR DESCRIPTION
This commit introduces internationalization for the POS and Super Admin dashboards, supporting both English and Arabic. It also adds a feature to display the table number in the POS queue for orders made via QR codes.

- Added missing translation keys for Super Admin and POS dashboards in `en.json` and `ar.json`.
- Replaced hardcoded strings in `POSDashboard.tsx` and `TableManagementTab.tsx` with `t()` function calls.
- Used the dynamic language from the `useTranslation` hook to format dates and numbers correctly.
- Implemented logic to fetch, cache, and display table numbers in the POS order queue.
- Added real-time fetching for new table numbers when they appear in incoming orders.